### PR TITLE
Implement interactive ranking selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Overwatch Discord Bot
+
+## 환경 변수
+
+| 이름 | 설명 |
+|------|------|
+| `SHOP_LOG_CHANNEL` | 아이템이나 역할 구매 로그를 전송할 채널 ID |

--- a/cogs/economy_cog.py
+++ b/cogs/economy_cog.py
@@ -11,6 +11,7 @@ import asyncio
 
 from core import OverwatchBot
 from core.utiles import money_to_string
+from view import RankingView
 
 
 class EconomyCog(commands.Cog):
@@ -92,17 +93,36 @@ class EconomyCog(commands.Cog):
 
         await interaction.response.send_message(f"{받는분.mention}님에게 {money_to_string(금액)}을 성공적으로 보냈습니다.")
 
-    @app_commands.command(name="랭킹", description="서버 내 재화 랭킹을 확인합니다.")
+    @app_commands.command(name="랭킹", description="서버 내 랭킹을 확인합니다.")
     async def leaderboard(self, interaction: discord.Interaction):
-        leaderboard_users = await self.bot.db.users.get_balance_leaderboard()
-        description = []
-        medals = ["🥇", "🥈", "🥉"]
-        for i, user in enumerate(leaderboard_users):
-            rank = medals[i] if i < 3 else f"{i + 1}."
-            description.append(f"{rank} **{user.display_name}**: {money_to_string(user.balance)}")
+        view = RankingView(self._send_leaderboard)
+        await interaction.response.send_message("확인할 랭킹 종류를 선택하세요.", view=view, ephemeral=True)
 
-        embed = discord.Embed(title="재화 랭킹", description="\n".join(description), color=discord.Color.blue())
-        await interaction.response.send_message(embed=embed)
+    async def _send_leaderboard(self, interaction: discord.Interaction, ranking_type: str):
+        limit = 50
+        if ranking_type == "activity":
+            users = await self.bot.db.users.get_activity_leaderboard(limit=limit)
+            users = [u for u in users if interaction.guild.get_member(u.user_id)][:10]
+            description = []
+            medals = ["🥇", "🥈", "🥉"]
+            for i, user in enumerate(users):
+                rank = medals[i] if i < 3 else f"{i + 1}."
+                description.append(
+                    f"{rank} **{user.display_name}**: {user.total_messages}메시지, {user.total_voice_minutes}분"
+                )
+            title = "활동량 랭킹"
+        else:
+            users = await self.bot.db.users.get_balance_leaderboard(limit=limit)
+            users = [u for u in users if interaction.guild.get_member(u.user_id)][:10]
+            description = []
+            medals = ["🥇", "🥈", "🥉"]
+            for i, user in enumerate(users):
+                rank = medals[i] if i < 3 else f"{i + 1}."
+                description.append(f"{rank} **{user.display_name}**: {money_to_string(user.balance)}")
+            title = "재화 랭킹"
+
+        embed = discord.Embed(title=title, description="\n".join(description), color=discord.Color.blue())
+        await interaction.response.edit_message(content=None, embed=embed, view=None)
 
     @app_commands.command(name="활동량", description="자신 또는 다른 유저의 활동량을 확인합니다.")
     @app_commands.describe(유저="활동량을 확인할 유저", 시작일="YYYY-MM-DD 형식", 종료일="YYYY-MM-DD 형식")

--- a/cogs/shop_cog.py
+++ b/cogs/shop_cog.py
@@ -13,6 +13,22 @@ from view import ShopView, NicknameChangeModal
 class ShopCog(commands.Cog, name="상점"):
     def __init__(self, bot: OverwatchBot):
         self.bot = bot
+        try:
+            self.log_channel_id = int(os.getenv("SHOP_LOG_CHANNEL"))
+        except (TypeError, ValueError):
+            self.log_channel_id = None
+
+    async def log_purchase(self, member: discord.Member, item_name: str, price: int):
+        if not self.log_channel_id:
+            return
+        channel = self.bot.get_channel(self.log_channel_id)
+        if not channel:
+            return
+        embed = discord.Embed(title="구매 로그", color=discord.Color.blue())
+        embed.add_field(name="구매자", value=member.mention, inline=False)
+        embed.add_field(name="상품", value=item_name, inline=False)
+        embed.add_field(name="가격", value=money_to_string(price), inline=False)
+        await channel.send(embed=embed)
 
     async def purchase_callback(self, interaction: discord.Interaction, item_id: int):
         item = await self.bot.db.shop.get_item_by_id(item_id)
@@ -30,6 +46,7 @@ class ShopCog(commands.Cog, name="상점"):
             await self.bot.db.shop.add_to_inventory(user.user_id, item.id)
             message = f"아이템 **{item.name}**을(를) 구매하여 인벤토리에 추가했습니다."
             await interaction.response.send_message(message, ephemeral=True)
+            await self.log_purchase(interaction.user, item.name, item.price)
 
         elif item.item_type == "ROLE":
             role = interaction.guild.get_role(item.role_id)
@@ -49,6 +66,7 @@ class ShopCog(commands.Cog, name="상점"):
                 await self.bot.db.shop.add_temporary_role(user.user_id, role.id, expires_at.isoformat())
                 message += f"\n이 역할은 **{item.duration_days}일** 후에 만료됩니다."
             await interaction.response.send_message(message, ephemeral=True)
+            await self.log_purchase(interaction.user, role.name, item.price)
 
         elif item.item_type == "NICKNAME_CHANGE":
 
@@ -57,6 +75,7 @@ class ShopCog(commands.Cog, name="상점"):
                     await modal_interaction.user.edit(nick=new_nickname)
                     await self.bot.db.users.update_display_name(user.user_id, new_nickname)
                     await modal_interaction.response.send_message(f"닉네임을 성공적으로 '{new_nickname}'(으)로 변경했습니다.", ephemeral=True)
+                    await self.log_purchase(modal_interaction.user, "닉네임 변경권", item.price)
                 except discord.Forbidden:
                     await self.bot.db.users.update_balance(user.user_id, item.price)  # 롤백
                     await modal_interaction.response.send_message("닉네임을 변경할 권한이 없습니다.", ephemeral=True)
@@ -66,7 +85,7 @@ class ShopCog(commands.Cog, name="상점"):
 
             modal = NicknameChangeModal(nickname_callback)
             await interaction.response.send_modal(modal)
-
+        
     @app_commands.command(name="상점", description="구매 가능한 아이템 및 역할 목록을 봅니다.")
     async def shop(self, interaction: discord.Interaction):
         user = await self.bot.db.users.get_or_create_user(interaction.user.id, interaction.user.display_name)

--- a/core/local/repository/user_repository.py
+++ b/core/local/repository/user_repository.py
@@ -1,7 +1,7 @@
 import aiosqlite
 from typing import Optional, List
 import datetime
-from core.model import User, ActivityLog, ActivityStats
+from core.model import User, ActivityLog, ActivityStats, ActivityLeaderboardEntry
 
 
 class UserRepository:
@@ -83,6 +83,30 @@ class UserRepository:
             total_messages=row[0] or 0,
             total_voice_minutes=(row[1] or 0) // 60
         )
+
+    async def get_activity_leaderboard(self, limit: int = 10) -> List[ActivityLeaderboardEntry]:
+        cursor = await self.db.execute(
+            "SELECT u.user_id, u.display_name, "
+            "COALESCE(SUM(a.message_count), 0) AS messages, "
+            "COALESCE(SUM(a.voice_seconds) / 60, 0) AS voice_minutes, "
+            "COALESCE(SUM(a.message_count), 0) + COALESCE(SUM(a.voice_seconds) / 60, 0) AS points "
+            "FROM users u "
+            "LEFT JOIN daily_activity a ON u.user_id = a.user_id "
+            "GROUP BY u.user_id "
+            "ORDER BY points DESC "
+            "LIMIT ?",
+            (limit,)
+        )
+        rows = await cursor.fetchall()
+        return [
+            ActivityLeaderboardEntry(
+                user_id=r["user_id"],
+                display_name=r["display_name"],
+                total_messages=int(r["messages"] or 0),
+                total_voice_minutes=int(r["voice_minutes"] or 0),
+            )
+            for r in rows
+        ]
 
     async def reset_all_balances(self) -> None:
         await self.db.execute("UPDATE users SET balance = 0")

--- a/core/model/user_models.py
+++ b/core/model/user_models.py
@@ -19,3 +19,10 @@ class ActivityLog:
 class ActivityStats:
     total_messages: int
     total_voice_minutes: int
+
+@dataclass
+class ActivityLeaderboardEntry:
+    user_id: int
+    display_name: str
+    total_messages: int
+    total_voice_minutes: int

--- a/view/__init__.py
+++ b/view/__init__.py
@@ -1,2 +1,3 @@
 from .shop_views import ShopView, ShopSelect, NicknameChangeModal
 from .role_views import RoleButtonView
+from .ranking_views import RankingView, RankingSelect

--- a/view/ranking_views.py
+++ b/view/ranking_views.py
@@ -1,0 +1,19 @@
+import discord
+
+class RankingView(discord.ui.View):
+    def __init__(self, select_callback):
+        super().__init__(timeout=30)
+        self.select_callback = select_callback
+        options = [
+            discord.SelectOption(label="재화", value="balance"),
+            discord.SelectOption(label="활동량", value="activity"),
+        ]
+        self.add_item(RankingSelect(options))
+
+class RankingSelect(discord.ui.Select):
+    def __init__(self, options):
+        super().__init__(placeholder="랭킹 종류를 선택하세요.", min_values=1, max_values=1, options=options)
+
+    async def callback(self, interaction: discord.Interaction):
+        await self.view.select_callback(interaction, self.values[0])
+


### PR DESCRIPTION
## Summary
- 랭킹 명령어를 드롭다운으로 선택하도록 수정하고 서버에 남아있는 멤버만 표시
- 랭킹용 뷰(`RankingView`) 추가

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687f6c0a66bc8331bb278f1ce6d392e4