### PR TITLE
feat: add item leaderboard command

### DIFF
--- a/core/model/__init__.py
+++ b/core/model/__init__.py
@@ -1,4 +1,4 @@
-from .shop_models import ShopItem, InventoryItem, TemporaryRole
+from .shop_models import ShopItem, InventoryItem, TemporaryRole, ItemLeaderboardEntry
 from .user_models import User, ActivityLog, ActivityStats, ActivityLeaderboardEntry
 from .moderation_models import ModerationLog
 from .role_message_models import RoleButton, RoleMessage

--- a/core/model/shop_models.py
+++ b/core/model/shop_models.py
@@ -18,6 +18,12 @@ class InventoryItem:
     count: int
 
 @dataclass
+class ItemLeaderboardEntry:
+    user_id: int
+    display_name: str
+    count: int
+
+@dataclass
 class TemporaryRole:
     id: int
     user_id: int

--- a/view/__init__.py
+++ b/view/__init__.py
@@ -1,3 +1,5 @@
 from .shop_views import ShopView, ShopSelect, NicknameChangeModal
 from .role_views import RoleButtonView
 from .ranking_views import RankingView, RankingSelect
+from .item_views import ItemSelectView, ItemSelect
+

--- a/view/item_views.py
+++ b/view/item_views.py
@@ -1,0 +1,20 @@
+import discord
+from core.model import ShopItem
+
+class ItemSelectView(discord.ui.View):
+    def __init__(self, items: list[ShopItem], select_callback):
+        super().__init__(timeout=30)
+        self.select_callback = select_callback
+        options = [
+            discord.SelectOption(label=item.name, value=str(item.id), emoji=item.emoji)
+            for item in items
+        ]
+        self.add_item(ItemSelect(options))
+
+class ItemSelect(discord.ui.Select):
+    def __init__(self, options: list[discord.SelectOption]):
+        super().__init__(placeholder="아이템을 선택하세요.", min_values=1, max_values=1, options=options)
+
+    async def callback(self, interaction: discord.Interaction):
+        await self.view.select_callback(interaction, int(self.values[0]))
+


### PR DESCRIPTION
## Summary
- add ItemLeaderboardEntry model and repository query to track top item holders
- implement dropdown view for item selection
- add admin-only command to display item ownership ranking

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896fe3707f08331b3634231d0b0df89